### PR TITLE
close #1 inaccesible files and directories

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -20,7 +20,7 @@ import * as path from 'path';
 import * as tmp from 'tmp';
 
 export class FixtureContent {
-  constructor(public content: string | Fixtures, public mode = 0o000) {}
+  constructor (public content: string | Fixtures, public mode = 0o000) { }
   toFixture(key: string): Fixtures {
     return { [key]: this.content };
   }
@@ -37,7 +37,7 @@ export async function setupFixtures(
   dir: string,
   fixtures: Fixtures
 ): Promise<string[]> {
-  let unaccessibleFixtures: string[] = [];
+  let inaccessibleFixtures: string[] = [];
   const keys = Object.keys(fixtures);
 
   for (const key of keys) {
@@ -47,27 +47,27 @@ export async function setupFixtures(
     if (typeof contents === 'string') {
       fs.writeFileSync(filePath, contents);
     } else if (contents instanceof FixtureContent) {
-      const deepUnaccessibleFixtures = await setupFixtures(
+      const deepinaccessibleFixtures = await setupFixtures(
         dir,
         contents.toFixture(key)
       );
       fs.chmodSync(filePath, contents.mode);
-      unaccessibleFixtures = [
+      inaccessibleFixtures = [
         filePath,
-        ...deepUnaccessibleFixtures,
-        ...unaccessibleFixtures,
+        ...deepinaccessibleFixtures,
+        ...inaccessibleFixtures,
       ];
     } else {
       await makeDir(filePath);
       const fixture = fixtures[key] as Fixtures;
-      const deepUnaccessibleFixtures = await setupFixtures(filePath, fixture);
-      unaccessibleFixtures = [
-        ...deepUnaccessibleFixtures,
-        ...unaccessibleFixtures,
+      const deepinaccessibleFixtures = await setupFixtures(filePath, fixture);
+      inaccessibleFixtures = [
+        ...deepinaccessibleFixtures,
+        ...inaccessibleFixtures,
       ];
     }
   }
-  return unaccessibleFixtures;
+  return inaccessibleFixtures;
 }
 
 export async function withFixtures(
@@ -77,7 +77,7 @@ export async function withFixtures(
   const keep = !!process.env.INLINE_FIXTURES_KEEP;
   const dir = tmp.dirSync({ keep, unsafeCleanup: true });
 
-  const unaccessibleFixtures = await setupFixtures(dir.name, fixtures);
+  const inaccessibleFixtures = await setupFixtures(dir.name, fixtures);
 
   const origDir = process.cwd();
   process.chdir(dir.name);
@@ -85,7 +85,7 @@ export async function withFixtures(
   try {
     return await fn(dir.name);
   } finally {
-    unaccessibleFixtures.forEach((filePath: string) =>
+    inaccessibleFixtures.forEach((filePath: string) =>
       fs.chmodSync(filePath, 0o777)
     );
     process.chdir(origDir);

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -19,26 +19,45 @@ import makeDir from 'make-dir';
 import * as path from 'path';
 import * as tmp from 'tmp';
 
+export class FixtureContent {
+  constructor(public content: string | Fixtures, public mode = 0o000) {}
+  toFixture(key: string): Fixtures {
+    return { [key]: this.content };
+  }
+}
+
 export interface Fixtures {
   // If string, we create a file with that string contents. If fixture, we
   // create a subdirectory and recursively install the fixture.
   // TODO: support buffers to allow non-text files.
-  [name: string]: string | Fixtures;
+  [name: string]: string | Fixtures | FixtureContent;
 }
 
-export async function setupFixtures(dir: string, fixtures: Fixtures) {
-  await makeDir(dir);
+export async function setupFixtures(
+  dir: string,
+  fixtures: Fixtures
+): Promise<string[]> {
   const keys = Object.keys(fixtures);
   for (const key of keys) {
     const filePath = path.join(dir, key);
-    if (typeof fixtures[key] === 'string') {
-      const contents = fixtures[key] as string;
+    const contents = fixtures[key];
+    if (typeof contents === 'string') {
       await fs.writeFileSync(filePath, contents);
+    } else if (contents instanceof FixtureContent) {
+      const unaccessibleFixtures = await setupFixtures(
+        dir,
+        contents.toFixture(key)
+      );
+      fs.chmodSync(filePath, contents.mode);
+      unaccessibleFixtures.unshift(filePath);
+      return unaccessibleFixtures;
     } else {
+      await makeDir(filePath);
       const fixture = fixtures[key] as Fixtures;
-      await setupFixtures(filePath, fixture);
+      return setupFixtures(filePath, fixture);
     }
   }
+  return [];
 }
 
 export async function withFixtures(
@@ -48,7 +67,7 @@ export async function withFixtures(
   const keep = !!process.env.INLINE_FIXTURES_KEEP;
   const dir = tmp.dirSync({ keep, unsafeCleanup: true });
 
-  await setupFixtures(dir.name, fixtures);
+  const unaccessibleFixtures = await setupFixtures(dir.name, fixtures);
 
   const origDir = process.cwd();
   process.chdir(dir.name);
@@ -56,6 +75,9 @@ export async function withFixtures(
   try {
     return await fn(dir.name);
   } finally {
+    unaccessibleFixtures.forEach((filePath: string) =>
+      fs.chmodSync(filePath, 0o777)
+    );
     process.chdir(origDir);
     if (!keep) {
       dir.removeCallback();

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -20,7 +20,7 @@ import * as path from 'path';
 import * as tmp from 'tmp';
 
 export class FixtureContent {
-  constructor (public content: string | Fixtures, public mode = 0o000) { }
+  constructor(public content: string | Fixtures, public mode = 0o000) {}
   toFixture(key: string): Fixtures {
     return { [key]: this.content };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-export { Fixtures, withFixtures } from './fixtures';
+export {
+  Fixtures,
+  withFixtures,
+  FixtureContent as WrongFile,
+} from './fixtures';

--- a/test/test-fixtures.ts
+++ b/test/test-fixtures.ts
@@ -57,7 +57,7 @@ describe(__filename, () => {
       }
     });
 
-    it('should create an unaccessible file', async () => {
+    it('should create an inaccessible file', async () => {
       const dir = tmp.dirSync({ unsafeCleanup: true });
       try {
         const password = '123456';
@@ -72,7 +72,7 @@ describe(__filename, () => {
       }
     });
 
-    it('should create an unaccessible directory', async () => {
+    it('should create an inaccessible directory', async () => {
       const dir = tmp.dirSync({ unsafeCleanup: true });
       try {
         const SUBFIXTURES = {
@@ -81,10 +81,10 @@ describe(__filename, () => {
         const FIXTURES = {
           private: new FixtureContent(SUBFIXTURES),
         };
-        const unaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
+        const inaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
         const indexPath = path.join(dir.name, 'private', 'README.md');
         assert.throws(() => fs.readFileSync(indexPath, 'utf8'));
-        unaccessibleFixtures.forEach((filePath: string) =>
+        inaccessibleFixtures.forEach((filePath: string) =>
           fs.chmodSync(filePath, 0o777)
         );
       } finally {
@@ -92,7 +92,7 @@ describe(__filename, () => {
       }
     });
 
-    it('should work with nested unaccessible directories', async () => {
+    it('should work with nested inaccessible directories', async () => {
       const dir = tmp.dirSync({ unsafeCleanup: true });
       try {
         const DEEPERFIXTURES = {
@@ -104,7 +104,7 @@ describe(__filename, () => {
         const FIXTURES = {
           private: new FixtureContent(DEEPFIXTURES),
         };
-        const unaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
+        const inaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
         const indexPath = path.join(
           dir.name,
           'private',
@@ -112,7 +112,7 @@ describe(__filename, () => {
           'SECRET.key'
         );
         assert.throws(() => fs.readFileSync(indexPath, 'utf8'));
-        unaccessibleFixtures.forEach((filePath: string) =>
+        inaccessibleFixtures.forEach((filePath: string) =>
           fs.chmodSync(filePath, 0o777)
         );
       } finally {
@@ -138,9 +138,9 @@ describe(__filename, () => {
           private: new FixtureContent(DEEPFIXTURES, 0o644),
           'README.md': 'Hello World.',
         };
-        const unaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
+        const inaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
 
-        // test SECRET.key is unaccessible
+        // test SECRET.key is inaccessible
         const indexPath = path.join(
           dir.name,
           'private',
@@ -150,7 +150,7 @@ describe(__filename, () => {
         assert.throws(() => fs.readFileSync(indexPath, 'utf8'));
 
         // freeing all up and testing accessibility
-        unaccessibleFixtures.forEach((filePath: string) => {
+        inaccessibleFixtures.forEach((filePath: string) => {
           fs.chmodSync(filePath, 0o777);
           assert.doesNotThrow(() => fs.accessSync(filePath));
         });

--- a/test/test-fixtures.ts
+++ b/test/test-fixtures.ts
@@ -175,6 +175,26 @@ describe(__filename, () => {
       assert.strict(process.cwd(), origDir);
     });
 
+    it('should work with inaccessible assets', async () => {
+      const SUBFIXTURES = {
+        'README.md': 'Hello World.',
+      };
+      const FIXTURES = {
+        private: new FixtureContent(SUBFIXTURES),
+      };
+      const origDir = process.cwd();
+      let readmePath: string;
+
+      await withFixtures(FIXTURES, async fixturesDir => {
+        assert.strictEqual(process.cwd(), fs.realpathSync(fixturesDir));
+        readmePath = path.join(fixturesDir, 'private', 'README.md');
+        assert.throws(() => fs.readFileSync(readmePath, 'utf8'));
+      });
+      assert.strict(process.cwd(), origDir);
+      // test that the directory is removed
+      assert.throws(() => fs.readFileSync(readmePath, 'utf8'));
+    });
+
     it('should cleanup temporary directories');
     it('should keep temporary directories when INLINE_FIXTURES_KEEP is set');
   });

--- a/test/test-fixtures.ts
+++ b/test/test-fixtures.ts
@@ -139,6 +139,8 @@ describe(__filename, () => {
           'README.md': 'Hello World.',
         };
         const unaccessibleFixtures = await setupFixtures(dir.name, FIXTURES);
+
+        // test SECRET.key is unaccessible
         const indexPath = path.join(
           dir.name,
           'private',
@@ -146,9 +148,12 @@ describe(__filename, () => {
           'SECRET.key'
         );
         assert.throws(() => fs.readFileSync(indexPath, 'utf8'));
-        unaccessibleFixtures.forEach((filePath: string) =>
-          fs.chmodSync(filePath, 0o777)
-        );
+
+        // freeing all up and testing accessibility
+        unaccessibleFixtures.forEach((filePath: string) => {
+          fs.chmodSync(filePath, 0o777);
+          assert.doesNotThrow(() => fs.accessSync(filePath));
+        });
       } finally {
         dir.removeCallback();
       }


### PR DESCRIPTION
Allow to specify type FixtureContent in Fixtures.
FixtureContent will create a file or directory with permission.
This will enable the consumer to test against EACCESS exceptions.